### PR TITLE
Disable fmriprep dummy scan detection

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -47,7 +47,7 @@ jobs:
     
     # Docker Hub image that `container-job` executes in
     # Use latest
-    container: mindandbrain/halfpipe:latest
+    container: ghcr.io/halfpipe/halfpipe:latest
     
     timeout-minutes: 360
 

--- a/halfpipe/workflow/fmriprep.py
+++ b/halfpipe/workflow/fmriprep.py
@@ -87,6 +87,7 @@ class FmriprepFactory(Factory):
                 "participant_label": bidssubjects,
                 "ignore": ignore,
                 "use_aroma": False,
+                "dummy_scans": 0,  # force user to take care of this manually
                 "skull_strip_t1w": skull_strip_t1w,
                 "anat_only": spec.global_settings["anat_only"],
                 "write_graph": spec.global_settings["write_graph"],


### PR DESCRIPTION
- fMRIPrep automatically detects non steady-state volumes using an algorithm
- This may confuse task event timings
- So we disable this feature