### PR TITLE
Fix `t2z_convert`, `chisq2z_convert` and `f2z_convert` performance

### DIFF
--- a/halfpipe/stats/flame1.py
+++ b/halfpipe/stats/flame1.py
@@ -14,7 +14,7 @@ from math import isnan, isclose, isfinite
 import numpy as np
 import pandas as pd
 import nibabel as nib
-from scipy import optimize
+from scipy.optimize import minimize_scalar
 
 from .miscmaths import t2z_convert, f2z_convert
 from .base import ModelAlgorithm, listwise_deletion, demean
@@ -57,7 +57,7 @@ def marg_posterior_energy(x, y, z, s):
 
 
 def solveforbeta(y, z, s):
-    res = optimize.minimize_scalar(
+    res = minimize_scalar(
         marg_posterior_energy, args=(y, z, s), method="brent"
     )
     fu = res.x

--- a/halfpipe/stats/miscmaths.py
+++ b/halfpipe/stats/miscmaths.py
@@ -75,7 +75,7 @@ def auto_convert(cdf: Callable, *args: Union[float, int]) -> float:
 
         p = None
 
-        while mp.prec < 2 ** 14:
+        while mp.prec < 2 ** 13:
             p = cdf(*map(mpmathify, args))
 
             if not mp.almosteq(p, mpf("1")) and not mp.almosteq(p, mpf("0")):
@@ -89,7 +89,7 @@ def auto_convert(cdf: Callable, *args: Union[float, int]) -> float:
             if mp.prec < 2 ** 12:
                 mp.prec += 2 ** 8
             else:
-                mp.prec += mp.prec
+                mp.prec += 2 ** 12
 
         # skip calculation
 

--- a/halfpipe/stats/tests/test_miscmaths.py
+++ b/halfpipe/stats/tests/test_miscmaths.py
@@ -6,6 +6,7 @@
 
 import pytest
 
+import sys
 import math
 
 import numpy as np
@@ -62,7 +63,9 @@ def test_chisq2z_convert_numpy(x, k):
 @pytest.mark.parametrize("t", np.logspace(1, 4, num=5))
 @pytest.mark.parametrize("dof", [2, 10, 30])
 def test_t2z_convert_large(t, dof):
-    assert math.isfinite(t2z_convert(t, dof))
+    z = t2z_convert(t, dof)
+    assert math.isfinite(z)
+    assert math.isclose(z, -t2z_convert(-t, dof))  # symmetric
 
 
 @pytest.mark.parametrize("x", np.logspace(1, 3, num=5))
@@ -77,6 +80,45 @@ def test_chisq2z_convert_large(x, k):
 ])
 def test_f2z_convert_large(f, d1, d2):
     assert math.isfinite(f2z_convert(f, d1, d2))
+
+
+# huge number tests
+
+@pytest.mark.parametrize("t", [
+    *np.logspace(5, 16, num=5),
+    sys.float_info.max,
+])
+@pytest.mark.parametrize("dof", [30])
+@pytest.mark.timeout(600)
+def test_t2z_convert_huge(t, dof):
+    z = t2z_convert(t, dof)
+    assert math.isclose(z, -t2z_convert(-t, dof))  # symmetric
+
+
+@pytest.mark.parametrize("x", [
+    sys.float_info.min,
+    *np.logspace(-16, -4, num=5),
+    *np.logspace(4, 16, num=5),
+    sys.float_info.max,
+])
+@pytest.mark.parametrize("k", [30])
+@pytest.mark.timeout(600)
+def test_chisq2z_convert_huge(x, k):
+    assert isinstance(chisq2z_convert(x, k), float)
+
+
+@pytest.mark.parametrize("f", [
+    sys.float_info.min,
+    *np.logspace(-16, -4, num=5),
+    *np.logspace(5, 16, num=5),
+    sys.float_info.max,
+])
+@pytest.mark.parametrize("d1,d2", [
+    (10, 100),
+])
+@pytest.mark.timeout(600)
+def test_f2z_convert_huge(f, d1, d2):
+    assert isinstance(f2z_convert(f, d1, d2), float)
 
 
 @pytest.mark.timeout(1)


### PR DESCRIPTION
- Use custom `erfinv` with a higher error tolerance for the root finding
  procedure
- Use mpmath's own `autoprec` instead of custom implementation
- Improve code re-use between distributions
- Add timed test cases for large numbers