### PR TITLE
Fix slowness during `t2z_convert`

### DIFF
--- a/halfpipe/interface/resultdict/datasink.py
+++ b/halfpipe/interface/resultdict/datasink.py
@@ -164,7 +164,7 @@ class ResultdictDatasink(SimpleInterface):
                 outpath = derivatives_directory
                 if "sub" not in tags:
                     outpath = grouplevel_directory
-                if key in ["effect", "variance", "z", "dof", "mean", "sem"]:  # apply rule
+                if key in ["effect", "variance", "z", "dof", "mean", "std"]:  # apply rule
                     outpath = outpath / _make_path(inpath, "image", tags, "statmap", stat=key)
                 else:
                     outpath = outpath / _make_path(inpath, "image", tags, key)

--- a/halfpipe/stats/descriptive.py
+++ b/halfpipe/stats/descriptive.py
@@ -17,7 +17,7 @@ from .base import ModelAlgorithm, listwise_deletion
 
 
 class Descriptive(ModelAlgorithm):
-    outputs = ["mean", "sem"]
+    outputs = ["mean", "std"]
 
     @staticmethod
     def voxel_calc(
@@ -47,7 +47,7 @@ class Descriptive(ModelAlgorithm):
 
             voxel_result[name][coordinate] = dict(
                 mean=cmat @ zframe.mean(),
-                sem=cmat @ zframe.sem(),
+                std=cmat @ zframe.std(),
             )
 
         return voxel_result

--- a/halfpipe/stats/miscmaths.py
+++ b/halfpipe/stats/miscmaths.py
@@ -4,7 +4,8 @@
 """
 """
 
-from typing import Callable, Union
+from typing import Type, Union
+from abc import ABC, abstractclassmethod
 
 import math
 
@@ -29,40 +30,81 @@ def normppf(p: mpf) -> mpf:
     return mp.sqrt(mpf("2")) * erfinv(a)  # inverse normal cdf
 
 
-def tcdf(x: mpf, nu: mpf) -> mpf:
-    x2 = x * x
-    z = nu / (nu + x2)
-    p = mp.betainc(
-        nu / mpf("2"),
-        mpf("1") / mpf("2"),
-        x1=mpf("0"),
-        x2=z,
-        regularized=True,
-    ) / mpf("2")
+class Distribution(ABC):
+    @abstractclassmethod
+    def cdf(cls, *args: mpf) -> mpf:
+        raise NotImplementedError
 
-    if x > mpf("0"):
-        return mpf("1") - p
-    else:
-        return p
+    @classmethod
+    def cdfc(cls, *args: mpf) -> mpf:
+        return mpf("1") - cls.cdf(*args)
 
 
-def fcdf(x: mpf, d1: mpf, d2: mpf) -> mpf:
-    return mp.betainc(
-        d1 / mpf("2"),
-        d2 / mpf("2"),
-        x1=mpf("0"),
-        x2=d1 * x / (d1 * x + d2),
-        regularized=True,
-    )
+class TDistribution(Distribution):
+    @classmethod
+    def cdf(cls, x: mpf, nu: mpf) -> mpf:
+        x2 = x * x
+        z = nu / (nu + x2)
+
+        p = mp.betainc(
+            nu / mpf("2"),
+            mpf("1") / mpf("2"),
+            x1=mpf("0"),
+            x2=z,
+            regularized=True,
+        ) / mpf("2")
+
+        if x > mpf("0"):
+            return mpf("1") - p
+        else:
+            return p
+
+    @classmethod
+    def cdfc(cls, x: mpf, nu: mpf) -> mpf:
+        return cls.cdf(-x, nu)
 
 
-def chisqcdf(x: mpf, k: mpf) -> mpf:
-    a = k / mpf("2")
+class FDistribution(Distribution):
+    @staticmethod
+    def _integral(x: mpf, d1: mpf, d2: mpf, inv: bool):
+        z = d1 * x / (d1 * x + d2)
 
-    return mp.gammainc(a, 0, x / mpf("2")) / mp.gamma(a)
+        if inv is False:
+            integral_range = dict(x1=mpf("0"), x2=z)
+        else:
+            integral_range = dict(x1=z, x2=mpf("1"))
+
+        return mp.betainc(
+            d1 / mpf("2"),
+            d2 / mpf("2"),
+            **integral_range,
+            regularized=True,
+        )
+
+    @classmethod
+    def cdf(cls, x: mpf, d1: mpf, d2: mpf) -> mpf:
+        return cls._integral(x, d1, d2, inv=False)
+
+    @classmethod
+    def cdfc(cls, x: mpf, d1: mpf, d2: mpf) -> mpf:
+        return cls._integral(x, d1, d2, inv=True)
 
 
-def auto_convert(cdf: Callable, *args: Union[float, int]) -> float:
+class ChisqDistribution(Distribution):
+    @classmethod
+    def cdf(cls, x: mpf, k: mpf) -> mpf:
+        return mp.gammainc(k / mpf("2"), 0, x / mpf("2"), regularized=True)
+
+    @classmethod
+    def cdfc(cls, x: mpf, k: mpf) -> mpf:
+        return mp.gammainc(k / mpf("2"), x / mpf("2"), mp.inf, regularized=True)
+
+
+def auto_convert(
+    d: Type[Distribution],
+    *args: Union[float, int],
+    max_prec: int = 2 ** 12
+) -> float:
     if any(math.isnan(a) for a in args):
         return math.nan  # skip computation
 
@@ -71,21 +113,32 @@ def auto_convert(cdf: Callable, *args: Union[float, int]) -> float:
 
     prec = mp.prec
 
+    cdf = d.cdf
+    p = cdf(*map(mpmathify, args))
+
+    use_complement = mp.almosteq(p, mpf("1"))
+    # it required many more bits to represent a number close to one than a
+    # number close to zero
+    if use_complement:
+        cdf = d.cdfc
+
+    z = math.nan
+
     try:
         # infer base precision
 
-        p = cdf(*map(mpmathify, args))
-
-        while mp.prec < 2 ** 14:
+        while mp.prec < max_prec:
             p = cdf(*map(mpmathify, args))
 
             if not mp.almosteq(p, mpf("1")) and not mp.almosteq(p, mpf("0")):
 
                 # we have sufficient precision to represent the p-value
 
-                return float(
+                z = float(
                     autoprec(lambda: normppf(cdf(*map(mpf, args))))()
                 )
+
+                break
 
             if mp.prec <= 2 ** 12:
                 mp.prec += 2 ** 8
@@ -96,32 +149,36 @@ def auto_convert(cdf: Callable, *args: Union[float, int]) -> float:
 
         mp.prec = prec  # reset precision so that almosteq cannot fail
 
-        if mp.almosteq(p, mpf("1")):
-            return math.inf
-        elif mp.almosteq(p, mpf("0")):
-            return -math.inf
+        if not math.isfinite(z):
+            if mp.almosteq(p, mpf("1")):
+                z = math.inf
+            else:
+                assert mp.almosteq(p, mpf("0"))
+                z = -math.inf
 
-        raise RuntimeError()  # should never be reached
+        if use_complement:
+            z = -z
 
+        return z
     finally:
         mp.prec = prec
 
 
-def t2z_convert(x: float, nu: int) -> float:
-    return auto_convert(tcdf, x, nu)
+def t2z_convert(x: float, nu: int, **kwargs) -> float:
+    return auto_convert(TDistribution, x, nu, **kwargs)
 
 
-def f2z_convert(x: float, d1: int, d2: int) -> float:
+def f2z_convert(x: float, d1: int, d2: int, **kwargs) -> float:
 
     if x <= 0 or d1 <= 0 or d2 <= 0:
         return -math.inf
 
-    return auto_convert(fcdf, x, d1, d2)
+    return auto_convert(FDistribution, x, d1, d2, **kwargs)
 
 
-def chisq2z_convert(x: float, k: int) -> float:
+def chisq2z_convert(x: float, k: int, **kwargs) -> float:
 
     if x <= mpf("0") or k <= mpf("0"):
         return -math.inf
 
-    return auto_convert(chisqcdf, x, k)
+    return auto_convert(ChisqDistribution, x, k, **kwargs)

--- a/halfpipe/stats/tests/test_miscmaths.py
+++ b/halfpipe/stats/tests/test_miscmaths.py
@@ -85,7 +85,7 @@ def test_f2z_convert_large(f, d1, d2):
 # huge number tests
 
 @pytest.mark.parametrize("t", [
-    *np.logspace(5, 16, num=5),
+    *np.logspace(5, 100, num=10),
     sys.float_info.max,
 ])
 @pytest.mark.parametrize("dof", [30])
@@ -97,8 +97,8 @@ def test_t2z_convert_huge(t, dof):
 
 @pytest.mark.parametrize("x", [
     sys.float_info.min,
-    *np.logspace(-16, -4, num=5),
-    *np.logspace(4, 16, num=5),
+    *np.logspace(-100, -4, num=10),
+    *np.logspace(4, 100, num=10),
     sys.float_info.max,
 ])
 @pytest.mark.parametrize("k", [30])
@@ -109,8 +109,8 @@ def test_chisq2z_convert_huge(x, k):
 
 @pytest.mark.parametrize("f", [
     sys.float_info.min,
-    *np.logspace(-16, -4, num=5),
-    *np.logspace(5, 16, num=5),
+    *np.logspace(-100, -4, num=10),
+    *np.logspace(5, 100, num=10),
     sys.float_info.max,
 ])
 @pytest.mark.parametrize("d1,d2", [

--- a/halfpipe/stats/tests/test_miscmaths.py
+++ b/halfpipe/stats/tests/test_miscmaths.py
@@ -89,7 +89,7 @@ def test_f2z_convert_large(f, d1, d2):
     sys.float_info.max,
 ])
 @pytest.mark.parametrize("dof", [30])
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(120)
 def test_t2z_convert_huge(t, dof):
     z = t2z_convert(t, dof)
     assert math.isclose(z, -t2z_convert(-t, dof))  # symmetric
@@ -102,7 +102,7 @@ def test_t2z_convert_huge(t, dof):
     sys.float_info.max,
 ])
 @pytest.mark.parametrize("k", [30])
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_chisq2z_convert_huge(x, k):
     assert isinstance(chisq2z_convert(x, k), float)
 
@@ -116,7 +116,7 @@ def test_chisq2z_convert_huge(x, k):
 @pytest.mark.parametrize("d1,d2", [
     (10, 100),
 ])
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(60)
 def test_f2z_convert_huge(f, d1, d2):
     assert isinstance(f2z_convert(f, d1, d2), float)
 

--- a/halfpipe/stats/tests/test_miscmaths.py
+++ b/halfpipe/stats/tests/test_miscmaths.py
@@ -102,7 +102,7 @@ def test_t2z_convert_huge(t, dof):
     sys.float_info.max,
 ])
 @pytest.mark.parametrize("k", [30])
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 def test_chisq2z_convert_huge(x, k):
     assert isinstance(chisq2z_convert(x, k), float)
 
@@ -116,7 +116,7 @@ def test_chisq2z_convert_huge(x, k):
 @pytest.mark.parametrize("d1,d2", [
     (10, 100),
 ])
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 def test_f2z_convert_huge(f, d1, d2):
     assert isinstance(f2z_convert(f, d1, d2), float)
 

--- a/halfpipe/workflow/base.py
+++ b/halfpipe/workflow/base.py
@@ -69,7 +69,7 @@ def init_workflow(workdir):
         crashdump_dir=workflow.base_dir,
         crashfile_format="txt",
         hash_method="content",
-        poll_sleep_duration=2,
+        poll_sleep_duration=0.5,
         use_relative_paths=False,
         check_version=False,
     ))

--- a/halfpipe/workflow/model/base.py
+++ b/halfpipe/workflow/model/base.py
@@ -99,7 +99,7 @@ def init_model_wf(
         name="make_resultdicts_a",
     )
 
-    statmaps = ["effect", "variance", "z", "dof", "mask", "mean", "sem"]
+    statmaps = ["effect", "variance", "z", "dof", "mask", "mean", "std"]
     make_resultdicts_b = pe.Node(
         MakeResultdicts(
             tagkeys=["model", "contrast"],


### PR DESCRIPTION
- Use incomplete beta function instead of hypergeometric function as
  done in boost https://github.com/boostorg/math/blob/b2538faaf9802af8e856c603b9001e33db826676/include/boost/math/distributions/students_t.hpp#L171-L202
- This means we can increase max precision and put stricter time limits
  on unit tests