### PR TITLE
Revert `slice_timing_offset` change

### DIFF
--- a/halfpipe/workflow/fmriprep.py
+++ b/halfpipe/workflow/fmriprep.py
@@ -82,9 +82,6 @@ class FmriprepFactory(Factory):
         ignore = []
         if global_settings["slice_timing"] is not True:
             ignore.append("slicetiming")
-            slice_timing_offset: float = 0
-        else:
-            slice_timing_offset = -0.5
 
         skull_strip_t1w = {
             "none": "skip",
@@ -208,7 +205,6 @@ class FmriprepFactory(Factory):
             inputnode.inputs.fd_thres = global_settings["fd_thres"]
 
             inputnode.inputs.repetition_time = database.metadata(bold_file_path, "repetition_time")
-            inputnode.inputs.slice_timing_offset = slice_timing_offset
 
             self.connect(hierarchy, inputnode, sourcefile=bold_file_path)
 

--- a/halfpipe/workflow/report/func.py
+++ b/halfpipe/workflow/report/func.py
@@ -23,8 +23,8 @@ from ..constants import constants
 from ..memory import MemoryCalculator
 
 
-def _calc_scan_start(skip_vols: int, slice_timing_offset: float, repetition_time: float) -> float:
-    return (skip_vols + slice_timing_offset) * repetition_time
+def _calc_scan_start(skip_vols: int, repetition_time: float) -> float:
+    return skip_vols * repetition_time
 
 
 def init_func_report_wf(workdir=None, name="func_report_wf", memcalc=MemoryCalculator.default()):
@@ -51,7 +51,6 @@ def init_func_report_wf(workdir=None, name="func_report_wf", memcalc=MemoryCalcu
                 *fmriprepreportdatasinks,
                 "fd_thres",
                 "repetition_time",
-                "slice_timing_offset",
                 "skip_vols",
                 "tags",
             ]
@@ -131,7 +130,7 @@ def init_func_report_wf(workdir=None, name="func_report_wf", memcalc=MemoryCalcu
     # based on https://github.com/bids-standard/bids-specification/issues/836#issue-954042717
     calc_scan_start = pe.Node(
         niu.Function(
-            input_names=["skip_vols", "slice_timing_offset", "repetition_time"],
+            input_names=["skip_vols", "repetition_time"],
             output_names="scan_start",
             function=_calc_scan_start,
         ),
@@ -139,7 +138,6 @@ def init_func_report_wf(workdir=None, name="func_report_wf", memcalc=MemoryCalcu
     )
     workflow.connect(inputnode, "skip_vols", calc_scan_start, "skip_vols")
     workflow.connect(inputnode, "repetition_time", calc_scan_start, "repetition_time")
-    workflow.connect(inputnode, "slice_timing_offset", calc_scan_start, "slice_timing_offset")
 
     workflow.connect(calc_scan_start, "scan_start", make_resultdicts, "scan_start")
 


### PR DESCRIPTION
- I misunderstood the original issue, apparently FSL FEAT takes the
  offset of half a repetition time into account anyway
- Explained here https://reproducibility.stanford.edu/slice-timing-correction-in-fmriprep-and-linear-modeling/