### PR TITLE
Reduce memory usage when running large workflows

### DIFF
--- a/halfpipe/cli/parser.py
+++ b/halfpipe/cli/parser.py
@@ -45,6 +45,7 @@ def build_parser():
 
     rungroup = parser.add_argument_group("run", "")
     rungroup.add_argument("--graphs-file", type=str, help="manually select graphs file")
+    rungroup.add_argument("--uuid", type=str, help="load graphs based on this uuid")
 
     rungroup.add_argument(
         "--subject-include",

--- a/halfpipe/io/cache.py
+++ b/halfpipe/io/cache.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+from typing import Any, Mapping, Optional, Union
+
+import pickle
+from uuid import UUID
+from pathlib import Path
+from shelve import open as open_shelf
+
+from .file.pickle import load_pickle_lzma, dump_pickle_lzma
+from ..utils import logger
+
+
+def _make_cache_file_path(type_str: str, uuid: Optional[Union[UUID, str]]):
+    if uuid is not None:
+        uuidstr = str(uuid)[:8]
+        path = f"{type_str}.{uuidstr}"
+    else:
+        path = f"{type_str}"
+    return path
+
+
+def uncache_obj(workdir: Union[Path, str], type_str: str, uuid: Union[UUID, str], display_str: str = None):
+    if display_str is None:
+        display_str = type_str
+
+    cache_file_path = str(
+        Path(workdir) / _make_cache_file_path(type_str, uuid)
+    )
+
+    try:
+        obj = load_pickle_lzma(cache_file_path)
+
+        if obj is not None:
+            if uuid is not None and hasattr(obj, "uuid"):
+                obj_uuid = getattr(obj, "uuid")
+                if obj_uuid is None or str(obj_uuid) != str(uuid):
+                    return None
+
+            logger.info(f"Using {display_str} from cache at {cache_file_path}")
+
+            return obj
+
+    except Exception:
+        pass
+
+    try:
+        return open_shelf(cache_file_path, flag="r")
+
+    except Exception:
+        pass
+
+    return None
+
+
+def cache_obj(workdir: Union[Path, str], type_str: str, obj: Any, uuid: Optional[Union[UUID, str]] = None):
+    if uuid is None:
+        uuid = getattr(obj, "uuid", None)
+
+    cache_file_path = str(
+        Path(workdir) / _make_cache_file_path(type_str, uuid)
+    )
+
+    if isinstance(obj, Mapping):
+        with open_shelf(
+            cache_file_path, flag="n", protocol=pickle.HIGHEST_PROTOCOL, writeback=True
+        ) as shelf:
+            shelf.update(obj)
+
+    else:
+        dump_pickle_lzma(cache_file_path, obj)

--- a/halfpipe/io/file/pickle.py
+++ b/halfpipe/io/file/pickle.py
@@ -2,60 +2,41 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
-from typing import Optional
+from typing import Any
 
+from pathlib import Path
 import lzma
 import pickle
-from uuid import UUID
 from traits.trait_errors import TraitError
-from pathlib import Path
 
 from ...utils import logger
 
+pickle_lzma_extension = ".pickle.xz"
 
-def load_pickle_lzma(filepath):
+
+def load_pickle_lzma(file_path: str):
+    if not file_path.endswith(pickle_lzma_extension):
+        file_path = f"{file_path}{pickle_lzma_extension}"
+
     try:
-        with lzma.open(filepath, "rb") as fptr:
+        with lzma.open(file_path, "rb") as fptr:
             return pickle.load(fptr)
+
     except (lzma.LZMAError, TraitError, EOFError) as e:
-        logger.error(f'Error while reading "{filepath}"', exc_info=e)
+        logger.error(f'Error while reading "{file_path}"', exc_info=e)
+        return None
 
 
-def dump_pickle_lzma(filepath, obj):
+def dump_pickle_lzma(file_path: str, obj: Any):
+    if not file_path.endswith(pickle_lzma_extension):
+        file_path = f"{file_path}{pickle_lzma_extension}"
+
+    if Path(file_path).is_file():
+        logger.warning(f'Overwriting existing file "{file_path}"')
+
     try:
-        with lzma.open(filepath, "wb") as fptr:
-            pickle.dump(obj, fptr)
+        with lzma.open(file_path, "wb") as fptr:
+            pickle.dump(obj, fptr, protocol=pickle.HIGHEST_PROTOCOL)
+
     except lzma.LZMAError as e:
-        logger.error(f'Error while writing "{filepath}"', exc_info=e)
-
-
-def _make_cache_file_path(type_str: str, uuid: Optional[UUID]):
-    if uuid is not None:
-        uuidstr = str(uuid)[:8]
-        path = f"{type_str}.{uuidstr}.pickle.xz"
-    else:
-        path = f"{type_str}.pickle.xz"
-    return path
-
-
-def uncache_obj(workdir, type_str: str, uuid: UUID, display_str: str = None):
-    if display_str is None:
-        display_str = type_str
-    path = Path(workdir) / _make_cache_file_path(type_str, uuid)
-    if path.exists():
-        obj = load_pickle_lzma(path)
-        if uuid is not None and hasattr(obj, "uuid"):
-            objuuid = getattr(obj, "uuid")
-            if objuuid is None or str(objuuid) != str(uuid):
-                return
-        logger.info(f"Cached {display_str} from {path}")
-        return obj
-
-
-def cache_obj(workdir, typestr, obj, uuid=None):
-    if uuid is None:
-        uuid = getattr(obj, "uuid", None)
-    path = Path(workdir) / _make_cache_file_path(typestr, uuid)
-    if path.exists():
-        logger.warning(f"Overwrite {path}")
-    dump_pickle_lzma(path, obj)
+        logger.error(f'Error while writing "{file_path}"', exc_info=e)

--- a/halfpipe/io/tests/test_cache.py
+++ b/halfpipe/io/tests/test_cache.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+from dataclasses import dataclass
+from pathlib import Path
+from shelve import Shelf
+
+from ..cache import cache_obj, uncache_obj
+
+
+@dataclass(frozen=True)
+class MockIdentifiable:
+    uuid: str
+
+
+def test_cache_uuid(tmp_path: Path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    uuid = "abcde"
+
+    x = MockIdentifiable(uuid=uuid)
+
+    cache_obj(workdir, "test", x)
+
+    y = uncache_obj(workdir, "test", uuid=uuid)
+
+    assert x == y
+
+
+def test_cache_uuid_mismatch(tmp_path: Path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    uuid = "abcde"
+
+    x = MockIdentifiable(uuid="12345")
+
+    cache_obj(workdir, "test", x, uuid=uuid)
+
+    y = uncache_obj(workdir, "test", uuid=uuid)
+
+    assert y is None
+
+
+def test_cache_mapping(tmp_path: Path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    uuid = "abcde"
+
+    x = dict(a="a", b="b", c="c")
+
+    cache_obj(workdir, "test", x, uuid=uuid)
+
+    y = uncache_obj(workdir, "test", uuid=uuid)
+
+    assert isinstance(y, Shelf)

--- a/halfpipe/workflow/base.py
+++ b/halfpipe/workflow/base.py
@@ -19,7 +19,7 @@ from .convert import convert_all
 from .constants import constants
 from .memory import MemoryCalculator
 from ..io.index import Database, BidsDatabase
-from ..io.file.pickle import cache_obj, uncache_obj
+from ..io.cache import cache_obj, uncache_obj
 from ..model.spec import loadspec
 from ..utils import logger, deepcopyfactory
 from .. import __version__
@@ -33,7 +33,7 @@ class IdentifiableWorkflow(pe.Workflow):
         self.bids_to_sub_id_map = dict()
 
 
-def init_workflow(workdir):
+def init_workflow(workdir) -> IdentifiableWorkflow:
     """
     initialize nipype workflow
 
@@ -49,6 +49,7 @@ def init_workflow(workdir):
 
     workflow = uncache_obj(workdir, ".workflow", uuid, display_str="workflow")
     if workflow is not None:
+        assert isinstance(workflow, IdentifiableWorkflow)
         return workflow
 
     # init classes that use the database


### PR DESCRIPTION
- Store graph chunks using the `shelve` module that is built into
  Python in `cache_obj`, and automatically detect this in `uncache_obj`
- Add unit tests for these methods
- This change means that we now only load the chunks that will be
  necessary
- Refactor the `run_step_run` method that merges and filters graphs before
  running to support this type of lazy loading
- Add `--uuid` cli option to automatically load the cached graphs by
  their identifier and independently of the format they are stored in
- Refactor cluster submission script generation