### PR TITLE
Fix BOLD to T1w registration issues with `use_bbr`

### DIFF
--- a/halfpipe/model/setting.py
+++ b/halfpipe/model/setting.py
@@ -21,6 +21,8 @@ class GlobalSettingsSchema(Schema):
 
     slice_timing = fields.Boolean(dump_default=False)
 
+    use_bbr = fields.Boolean(dump_default=True, allow_none=True)
+
     skull_strip_algorithm = fields.Str(
         validate=validate.OneOf(["none", "auto", "ants", "hdbet"]), dump_default="ants"
     )

--- a/halfpipe/workflow/report/func.py
+++ b/halfpipe/workflow/report/func.py
@@ -48,6 +48,7 @@ def init_func_report_wf(workdir=None, name="func_report_wf", memcalc=MemoryCalcu
                 "movpar_file",
                 "confounds",
                 "method",
+                "fallback",
                 *fmriprepreportdatasinks,
                 "fd_thres",
                 "repetition_time",
@@ -78,13 +79,14 @@ def init_func_report_wf(workdir=None, name="func_report_wf", memcalc=MemoryCalcu
     make_resultdicts = pe.Node(
         MakeResultdicts(
             reportkeys=["epi_norm_rpt", "tsnr_rpt", "carpetplot", *fmriprepreports],
-            valkeys=["dummy_scans", "sdc_method", "scan_start"],
+            valkeys=["dummy_scans", "sdc_method", "scan_start", "fallback_registration"],
         ),
         name="make_resultdicts",
     )
     workflow.connect(inputnode, "skip_vols", make_resultdicts, "dummy_scans")
     workflow.connect(inputnode, "tags", make_resultdicts, "tags")
     workflow.connect(inputnode, "method", make_resultdicts, "sdc_method")
+    workflow.connect(inputnode, "fallback", make_resultdicts, "fallback_registration")
 
     #
     resultdict_datasink = pe.Node(


### PR DESCRIPTION
- fMRIPrep may reject FLIRT+BBR registrations when they are very different from
  an initial registration (https://fmriprep.org/en/stable/workflows.html#epi-to-t1w-registration).
  This check was implemented to fix errors on specific datasets (nipreps/fmriprep#681).
- We can disable this behavior by setting `use_bbr` to `True`
- Also add the `fallback_registration` output to diagnose this behavior