### PR TITLE
Fix multiple small issues

### DIFF
--- a/halfpipe/cli/run.py
+++ b/halfpipe/cli/run.py
@@ -56,7 +56,7 @@ def run_stage_workflow(opts):
     workflow = init_workflow(opts.workdir)
 
     if workflow is None:
-        return
+        return None
 
     opts.graphs = init_execgraph(opts.workdir, workflow)
 
@@ -78,20 +78,20 @@ def run_stage_run(opts):
 
     else:
         if opts.graphs_file is not None:
-            from ..io.pickle import load_pickle_lzma
+            from ..utils.pickle import load_pickle
 
             graphs_file = str(resolve(opts.graphs_file, opts.fs_root))
 
             logger.info(f'Using graphs defined in file "{graphs_file}"')
 
-            obj = load_pickle_lzma(graphs_file)
+            obj = load_pickle(graphs_file)
             if not isinstance(obj, Mapping):
                 raise ValueError(f'Invalid graphs file "{graphs_file}"')
 
             graphs = obj
 
         elif opts.uuid is not None:
-            from ..io.cache import uncache_obj
+            from ..utils.cache import uncache_obj
 
             obj = uncache_obj(workdir, type_str="graphs", uuid=opts.uuid)
             if not isinstance(obj, Mapping):
@@ -306,6 +306,9 @@ def main():
 
     try:
         setup_logging_context()
+
+        from ..utils.pickle import patch_nipype_unpickler
+        patch_nipype_unpickler()
 
         from .parser import parse_args
         opts, should_run = parse_args()

--- a/halfpipe/hooks.py
+++ b/halfpipe/hooks.py
@@ -81,8 +81,6 @@ def run_hooks_from_dir(workdir: Path):
             if child.is_dir():
                 if (child / "__init__.py").exists():  # candidate dir is a module
                     plugins.append(child)
-                else:
-                    stack.append(child)
             elif isinstance(child, Path) and child.suffix == ".zip":
                 try:
                     zip_file = ZipFile(child)

--- a/halfpipe/ingest/resolve.py
+++ b/halfpipe/ingest/resolve.py
@@ -81,7 +81,8 @@ def to_fileobj(obj: BIDSFile, basemetadata: dict) -> File | None:
             log_method = logger.debug  # silence
 
         log_method(
-            f'Ignored validation error for "{path}": %s',
+            f'Skipping unsupported file "{path}" because %s',
+
             e,
             exc_info=False,
             stack_info=False,
@@ -227,11 +228,11 @@ class ResolvedSpec:
             intended_for_rules[fmapstr].append(funcstr)
 
         if len(intended_for) > 0:
-            logger.info("Inferred mapping between func and fmap files to be %s", pformat(intended_for))
+            logger.info("Inferred mapping between func and fmap files to be %s", pformat(intended_for_rules))
             for file in resolved_files:
                 if file.datatype != "fmap":
                     continue
-                file.intended_for = intended_for
+                file.intended_for = intended_for_rules
 
         return resolved_files
 

--- a/halfpipe/interfaces/connectivity.py
+++ b/halfpipe/interfaces/connectivity.py
@@ -9,7 +9,7 @@ from typing import Literal, overload
 import numpy as np
 import pandas as pd
 import nibabel as nib
-from scipy.ndimage.measurements import mean
+from scipy.ndimage import mean
 
 from nipype.interfaces.base import (
     BaseInterface,

--- a/halfpipe/plugins/multiproc.py
+++ b/halfpipe/plugins/multiproc.py
@@ -26,6 +26,9 @@ def initializer(workdir, logging_args, plugin_args, host_env):
     from ..logging import setup as setup_logging
     setup_logging(**logging_args)
 
+    from ..utils.pickle import patch_nipype_unpickler
+    patch_nipype_unpickler()
+
     watchdog = plugin_args.get("watchdog", False)
     if watchdog is True:
         from ..watchdog import init_watchdog

--- a/halfpipe/utils/future.py
+++ b/halfpipe/utils/future.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+import os
+from contextlib import AbstractContextManager
+
+class chdir(AbstractContextManager):
+    """
+    Non thread-safe context manager to change the current working directory.
+
+    Taken from https://github.com/python/cpython/commit/3592980f9122ab0d9ed93711347742d110b749c2
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self._old_cwd = []
+
+    def __enter__(self):
+        self._old_cwd.append(os.getcwd())
+        os.chdir(self.path)
+
+    def __exit__(self, *excinfo):
+        os.chdir(self._old_cwd.pop())

--- a/halfpipe/utils/path.py
+++ b/halfpipe/utils/path.py
@@ -2,13 +2,11 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
-from typing import Union
-
 from pathlib import Path
 from os.path import normpath
 
 
-def resolve(path: Union[Path, str], fs_root: Union[Path, str]) -> Path:
+def resolve(path: Path | str, fs_root: Path | str) -> Path:
 
     fs_root = str(fs_root)
 
@@ -53,7 +51,7 @@ def find_paths(obj):
     return paths
 
 
-def split_ext(fname):
+def split_ext(path: Path | str):
     """Splits filename and extension (.gz safe)
     >>> splitext('some/file.nii.gz')
     ('file', '.nii.gz')
@@ -64,16 +62,21 @@ def split_ext(fname):
     >>> splitext('text.txt')
     ('text', '.txt')
 
-    Source: niworkflows
+    Adapted from niworkflows
     """
     from pathlib import Path
 
-    basename = str(Path(fname).name)
-    stem = Path(basename.rstrip(".gz")).stem
-    return stem, basename[len(stem) :]
+    name = str(Path(path).name)
+
+    safe_name = name
+    for compound_extension in [".gz", ".xz"]:
+        safe_name = safe_name.removesuffix(compound_extension)
+
+    stem = Path(safe_name).stem
+    return stem, name[len(stem):]
 
 
-def is_empty(path) -> bool:
+def is_empty(path: Path | str) -> bool:
     from pathlib import Path
 
     path = Path(path)

--- a/halfpipe/utils/pickle.py
+++ b/halfpipe/utils/pickle.py
@@ -2,14 +2,19 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
-from typing import Any
+from typing import Callable, Literal
+from io import BufferedIOBase
 
 from pathlib import Path
 import lzma
 import pickle
 from traits.trait_errors import TraitError
+import re
+import gzip
 
 from . import logger
+from .path import split_ext
+from .future import chdir
 
 pickle_lzma_extension = ".pickle.xz"
 
@@ -27,7 +32,7 @@ def load_pickle_lzma(file_path: str):
         return None
 
 
-def dump_pickle_lzma(file_path: str, obj: Any):
+def dump_pickle_lzma(file_path: str, obj):
     if not file_path.endswith(pickle_lzma_extension):
         file_path = f"{file_path}{pickle_lzma_extension}"
 
@@ -40,3 +45,40 @@ def dump_pickle_lzma(file_path: str, obj: Any):
 
     except lzma.LZMAError as e:
         logger.error(f'Error while writing "{file_path}"', exc_info=e)
+
+
+class Unpickler(pickle.Unpickler):
+    def find_class(self, module: str, name: str):
+        module = re.sub(r"^halfpipe\.workflow(?=\.|$)", "halfpipe.workflows", module)
+        module = re.sub(r"^halfpipe\.interface(?=\.|$)", "halfpipe.interfaces", module)
+        return super(Unpickler, self).find_class(module, name)
+
+
+def load_pickle(file_path: str | Path):
+    file_path = Path(file_path)
+
+    _, file_extension = split_ext(file_path)
+
+    match file_extension:
+        case ".pkl":
+            file_open: Callable[[Path, Literal["rb"]], BufferedIOBase] = open
+        case ".pklz":
+            file_open = gzip.open
+        case ".pickle.xz":
+            file_open = lzma.open
+        case _:
+            raise ValueError()
+
+    with chdir(file_path.parent):
+        with file_open(file_path, "rb") as file_handle:
+            return Unpickler(file_handle).load()
+
+
+def patch_nipype_unpickler():
+    from nipype.utils import filemanip
+    from nipype.pipeline.engine import utils, nodes, base
+
+    filemanip.loadpkl = load_pickle
+    utils.loadpkl = load_pickle
+    nodes.loadpkl = load_pickle
+    base.loadpkl = load_pickle

--- a/halfpipe/utils/tests/test_path.py
+++ b/halfpipe/utils/tests/test_path.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from nipype.interfaces.base.support import Bunch
 
-from ..path import find_paths
+from ..path import find_paths, split_ext
 
 
 A = "/tmp/a.txt"  # TODO make this more elegant with a tmp_dir
@@ -29,7 +29,7 @@ B = "/tmp/b.txt"
         Bunch(x=[A, B])
     ]
 )
-def test_findpaths(tmp_path, obj):
+def test_find_paths(tmp_path, obj):
     os.chdir(str(tmp_path))
 
     for fname in [A, B]:
@@ -39,3 +39,8 @@ def test_findpaths(tmp_path, obj):
 
     for fname in [A, B]:
         Path(fname).unlink()
+
+
+def test_split_ext():
+    assert split_ext("a/a.nii.gz") == ("a", ".nii.gz")
+    assert split_ext("a/a.pickle.xz") == ("a", ".pickle.xz")


### PR DESCRIPTION
- `ModuleNotFoundError` for older pickle files, specifically when
  loading previous intermediate results via nipype
- Disable searching recursively for plugins in a working directory. It
  is sufficient to just search in the top level
- Fix imports from `halfpipe.io`
- Fix warnings