### PR TITLE
Remove abstract class property

### DIFF
--- a/halfpipe/cli/commands/base.py
+++ b/halfpipe/cli/commands/base.py
@@ -70,12 +70,6 @@ class AppendObjectAction(Action):
 
 
 class ObjectSetAttributeAction(Action):
-    @classmethod
-    @property
-    @abstractmethod
-    def field(cls) -> str:
-        raise NotImplementedError
-
     def __init__(
         self,
         option_strings: Sequence[str],


### PR DESCRIPTION
- Unsupported syntax for Python 3.11 https://github.com/python/mypy/issues/11619