### PR TITLE
Move container resources to `/var/cache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM nipreps/fmriprep:20.2.7
 
-ENV PATH="/usr/local/miniconda/bin:$PATH" \
-    XDG_CACHE_HOME="/home/fmriprep/.cache" \
-    HALFPIPE_RESOURCE_DIR="${XDG_CACHE_HOME}/halfpipe" \
-    TEMPLATEFLOW_HOME="${XDG_CACHE_HOME}/templateflow"
+RUN mkdir /ext /host \
+ && chmod a+rwx /ext /host
 
-RUN mkdir /ext /halfpipe \
- && chmod a+rwx /ext /halfpipe
+ENV PATH="/usr/local/miniconda/bin:$PATH"
+
+# Use `/var/cache` for downloaded resources instead of
+# `/home/fmriprep/.cache`, because it is less likely to be
+# obscured by default container bind mounts when running
+# with Singularity
+ENV XDG_CACHE_HOME="/var/cache" \
+    HALFPIPE_RESOURCE_DIR="/var/cache/halfpipe" \
+    TEMPLATEFLOW_HOME="/var/cache/templateflow"
+RUN mv /home/fmriprep/.cache/templateflow /var/cache
 
 # Re-install `conda` and dependency `python` packages
 COPY requirements.txt install-requirements.sh /tmp/
-
 RUN rm -rf /usr/local/miniconda \
  && cd /tmp \
  && curl --show-error --location \
@@ -19,11 +24,12 @@ RUN rm -rf /usr/local/miniconda \
  && bash miniconda.sh -b -p /usr/local/miniconda \
  && mamba install --yes "python=3.10" "nomkl" "pip" "gdb" "nodejs" \
  && ./install-requirements.sh --requirements-file requirements.txt \
+ && cd \
  && sync \
- && conda clean --yes --all --force-pkgs-dirs \
+ && mamba clean --yes --all --force-pkgs-dirs \
  && sync \
  && find /usr/local/miniconda/ -follow -type f -name "*.a" -delete \
- && rm -rf /tmp/* \
+ && rm -rf /tmp/* ~/.conda \
  && sync
 
 # Re-apply matplotlib settings after updating
@@ -35,7 +41,10 @@ RUN python -c "from matplotlib import font_manager" \
 
 # Download all resources
 COPY halfpipe/resource.py /tmp/
-RUN python /tmp/resource.py
+RUN python /tmp/resource.py \
+ && sync \
+ && rm -rf /tmp/* \
+ && sync
 
 # Add coinstac server components
 COPY --from=coinstacteam/coinstac-base:latest /server/ /server/
@@ -44,8 +53,7 @@ COPY --from=coinstacteam/coinstac-base:latest /server/ /server/
 COPY . /halfpipe/
 RUN cd /halfpipe \
  && /usr/local/miniconda/bin/python -m pip install --no-deps --no-cache-dir . \
- && rm -rf ~/.cache/pip ~/.conda \
  && cd \
- && rm -rf /halfpipe/* /tmp/*
+ && rm -rf ~/.cache/pip /halfpipe /tmp/*
 
 ENTRYPOINT ["/usr/local/miniconda/bin/halfpipe"]

--- a/halfpipe/__init__.py
+++ b/halfpipe/__init__.py
@@ -17,10 +17,14 @@ finally:
 os.environ["NIPYPE_NO_ET"] = "1"  # disable nipype update check
 os.environ["NIPYPE_NO_MATLAB"] = "1"
 
-xdg_cache_home = Path("/home/fmriprep/.cache")
-if xdg_cache_home.is_dir():
-    # we are likely running in a container, so we make sure to reset
-    # important env variables
+os.environ["MPLCONFIGDIR"] = mkdtemp()  # silence matplotlib warningddd
+
+# special variable set in the container
+if os.getenv("IS_DOCKER_8395080871") is not None:
+    # we are running in a container, so we reset important
+    # env variables to the correct values
+
+    xdg_cache_home = Path("/var/cache")
     os.environ["XDG_CACHE_HOME"] = str(
         xdg_cache_home
     )  # where matplotlib looks for the font cache
@@ -36,5 +40,3 @@ if xdg_cache_home.is_dir():
     )  # where templateflow.api looks for its cache
 
     del xdg_cache_home, halfpipe_resource_dir, templateflow_home
-
-os.environ["MPLCONFIGDIR"] = mkdtemp()  # silence matplotlib warning


### PR DESCRIPTION
- Prevent bind-mounting `/home` into the container from hiding the Templateflow cache directory, which used to be in `/home/fmriprep/.cache`
- Add more comments to Dockerfile