### PR TITLE
Fix #400 add limit for number of filter options to display

### DIFF
--- a/halfpipe/ui/setting/base.py
+++ b/halfpipe/ui/setting/base.py
@@ -56,7 +56,7 @@ def get_setting_init_steps(
                     continue
 
                 tagvals_set = set(tagvals_list)
-                if len(tagvals_set) > 1:
+                if 1 < len(tagvals_set) < 16:
                     self.entities.append(entity)
 
                     entity_str = entity


### PR DESCRIPTION
- A blinded data set had sessions coded by acquisition date, so that almost each subject had distinct session identifiers. This causes the SettingFilterStep to overflow the curses window.
- We fix this by only displaying at most 16 distinct choices.