### PR TITLE
Fix `group-level` command when inputs have underscores

### DIFF
--- a/halfpipe/cli/commands/group_level/command.py
+++ b/halfpipe/cli/commands/group_level/command.py
@@ -320,39 +320,39 @@ class GroupLevelCommand(Command):
                     arguments.nipype_n_procs,
                 )
 
-            for from_key, to_key in modelfit_aliases.items():
-                if from_key in output_files:
-                    output_files[to_key] = output_files.pop(from_key)
+                for from_key, to_key in modelfit_aliases.items():
+                    if from_key in output_files:
+                        output_files[to_key] = output_files.pop(from_key)
 
-            images = {
-                key: value
-                for key, value in output_files.items()
-                if isinstance(value, str)
-            }
-            images["design_matrix"] = str(design_tsv)
-            images["contrast_matrix"] = str(contrast_tsv)
-
-            model_results = list()
-
-            model_result = deepcopy(result)
-            if arguments.model_name is not None:
-                model_result["tags"]["model"] = arguments.model_name
-            model_result["images"] = images
-            model_results.append(model_result)
-
-            for i, contrast_name in enumerate(contrast_names):
                 images = {
-                    key: value[i]
+                    key: value
                     for key, value in output_files.items()
-                    if isinstance(value, list) and isinstance(value[i], str)
+                    if isinstance(value, str)
                 }
-                if len(images) == 0:
-                    continue
+                images["design_matrix"] = str(design_tsv)
+                images["contrast_matrix"] = str(contrast_tsv)
+
+                model_results = list()
+
                 model_result = deepcopy(result)
-                model_result["tags"]["contrast"] = contrast_name
                 if arguments.model_name is not None:
                     model_result["tags"]["model"] = arguments.model_name
                 model_result["images"] = images
                 model_results.append(model_result)
 
-            save_images(model_results, output_directory)
+                for i, contrast_name in enumerate(contrast_names):
+                    images = {
+                        key: value[i]
+                        for key, value in output_files.items()
+                        if isinstance(value, list) and isinstance(value[i], str)
+                    }
+                    if len(images) == 0:
+                        continue
+                    model_result = deepcopy(result)
+                    model_result["tags"]["contrast"] = contrast_name
+                    if arguments.model_name is not None:
+                        model_result["tags"]["model"] = arguments.model_name
+                    model_result["images"] = images
+                    model_results.append(model_result)
+
+                save_images(model_results, output_directory)

--- a/halfpipe/cli/commands/group_level/parser.py
+++ b/halfpipe/cli/commands/group_level/parser.py
@@ -93,6 +93,9 @@ def _parse_from_spec(
 
     filtered_results = list()
     seen_inputs: set[str] = set()
+
+    model_inputs: set[str] = set(map(format_like_bids, model.inputs))
+
     for result in results:
         tags = result["tags"]
 
@@ -102,7 +105,7 @@ def _parse_from_spec(
                 continue
             value = format_like_bids(value)
             seen_inputs.add(value)
-            if value in model.inputs:
+            if value in model_inputs:
                 filtered_results.append(result)
                 break
     results = filtered_results
@@ -112,7 +115,7 @@ def _parse_from_spec(
             [f'"{seen_input}"' for seen_input in sorted(seen_inputs)]
         )
         model_inputs_str = inflect_engine.join(
-            [f'"{model_input}"' for model_input in sorted(model.inputs)],
+            [f'"{model_input}"' for model_input in sorted(model_inputs)],
             conj="or",
         )
         raise ValueError(


### PR DESCRIPTION
- For the `--from-spec` option