### PR TITLE
Fix `QCDecisionMaker` for queries that include lists

### DIFF
--- a/halfpipe/exclude.py
+++ b/halfpipe/exclude.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from enum import Enum, IntEnum, auto
 from glob import glob, has_magic
 from pathlib import Path
-from typing import Generator, Mapping, Sequence
+from typing import Any, Generator, Mapping, Sequence
 
 from more_itertools import powerset
 from pyrsistent import pmap
@@ -54,9 +54,14 @@ class QCDecisionMaker:
             for entry in entries:
                 self._add_entry(entry)
 
-    def _normalize_value(self, tag: str, value: str) -> str:
+    def _normalize_value(self, tag: str, value: Any) -> str:
+        if isinstance(value, list):
+            if len(value) == 1:
+                (value,) = value
         if tag == "sub":
             value = normalize_subject(value)
+        if not isinstance(value, str):
+            raise ValueError
         return value
 
     def _add_entry(self, entry: Mapping[str, str]) -> None:
@@ -86,7 +91,7 @@ class QCDecisionMaker:
             if subset in self.index:
                 yield from self.index[subset]
 
-    def get(self, tags: Mapping[str, str]) -> Decision:
+    def get(self, tags: Mapping[str, Any]) -> Decision:
         if len(self.relevant_tag_names) == 0:
             relevant_tags = pmap(tags)
         else:

--- a/halfpipe/tests/test_exclude.py
+++ b/halfpipe/tests/test_exclude.py
@@ -46,3 +46,4 @@ def test_get(tmp_path, tags: Mapping[str, str], decision):
     assert qc.get(tags=dict(sub="PSY00")) == decision
     assert qc.get(tags=dict(sub="PSY_00")) == decision
     assert qc.get(tags=dict(sub="sub-PSY00")) == decision
+    assert qc.get(tags=dict(sub="sub-PSY00", run=["03"])) == decision


### PR DESCRIPTION
- In data sets with multiple runs or sessions, it can happen that for a subset of sessions, only one run or one session is available. For these subjects, we skip the fixed effects aggregation step and instead pass their one run or session directly to group statistics.
- We fix #490, where Anthony Juliano observed a crash in this case, where an `unhashable type` error occurred for such a result object
- This happened, because such result objects have a length one list in their tags, which tracks the run or session number that was passed to group stats
- To avoid the error, we simply unpack the length one list