### PR TITLE
Add different statistics to `--export-atlas` option

### DIFF
--- a/src/halfpipe/cli/commands/group_level/arguments.py
+++ b/src/halfpipe/cli/commands/group_level/arguments.py
@@ -235,10 +235,10 @@ def setup_argument_parser(argument_parser: ArgumentParser):
     group.add_argument(
         "--export-atlas",
         type=str,
-        nargs=3,
-        metavar=("NAME", "IMAGE_PATH", "LABEL_PATH"),
+        nargs=4,
+        metavar=("NAME", "TYPE", "IMAGE_PATH", "LABEL_PATH"),
         action="append",
-        help="for all images, export the mean region signals for the atlas defined by the image/label files",
+        help="for all images, export region signals based on the atlas defined by the image/label files",
     )
     group.add_argument(
         "--minimum-atlas-coverage",

--- a/src/halfpipe/cli/commands/group_level/export.py
+++ b/src/halfpipe/cli/commands/group_level/export.py
@@ -2,12 +2,13 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
-from collections import OrderedDict
+from abc import abstractmethod
 from contextlib import nullcontext
 from dataclasses import dataclass
-from functools import partial
+from enum import Enum, auto
+from functools import cached_property, partial
 from pathlib import Path
-from typing import ContextManager, Iterable, Literal, Self, Sequence
+from typing import ContextManager, Iterator, Self, Sequence
 
 import nibabel as nib
 import numpy as np
@@ -25,41 +26,195 @@ from ....utils.format import format_like_bids
 from ....utils.multiprocessing import Pool
 
 
+def load_atlas(
+    image_path: Path | str,
+    labels_path: Path | str,
+) -> tuple[dict[int, str], nib.analyze.AnalyzeImage]:
+    image_path = Path(image_path)
+
+    labels_frame = read_spreadsheet(labels_path)
+    labels: dict[int, str] = dict()
+    for label_tuple in labels_frame.itertuples(index=False):
+        # First columnn is the index, second is the name.
+        labels[int(label_tuple[0])] = format_like_bids(str(label_tuple[1]))
+
+    image = nib.nifti1.load(image_path)
+    return labels, image
+
+
+class Statistic(Enum):
+    z = auto()
+    effect = auto()
+    standardizedEffect = auto()
+    cohensD = auto()
+
+
+@dataclass
+class ImagePaths:
+    effect: Path
+    mask: Path
+
+    variance: Path | None = None
+    sigmasquareds: Path | None = None
+    dof: Path | None = None
+    z: Path | None = None
+
+    @cached_property
+    def effect_image(self) -> nib.analyze.AnalyzeImage:
+        return nib.nifti1.load(self.mask)
+
+    @cached_property
+    def mask_image(self) -> nib.analyze.AnalyzeImage:
+        return nib.nifti1.load(self.mask)
+
+    @property
+    def mask_data(self) -> npt.NDArray[np.bool_]:
+        return np.asanyarray(self.mask_image.dataobj, dtype=bool)
+
+    def get_data_image(
+        self, statistic: Statistic
+    ) -> tuple[Statistic, nib.analyze.AnalyzeImage]:
+        if statistic == Statistic.effect:
+            return statistic, nib.nifti1.load(self.effect)
+        elif statistic == Statistic.cohensD:
+            if self.sigmasquareds is None:
+                logger.info(
+                    f'Cannot find sigmasquareds image for image "{self.effect}"'
+                )
+                return self.get_data_image(Statistic.effect)
+            effect_image = self.effect_image
+            sigmasquareds_image = nib.nifti1.load(self.sigmasquareds)
+
+            effect = effect_image.get_fdata()
+            sigmasquareds = sigmasquareds_image.get_fdata()
+            mask = self.mask_data
+
+            d = np.zeros_like(effect)
+            d[mask] = effect[mask] / np.sqrt(sigmasquareds[mask])
+
+            d_image = new_img_like(effect_image, d, copy_header=True)
+            return Statistic.cohensD, d_image
+        elif statistic == Statistic.z:
+            if self.z is None:
+                logger.info(f'Cannot find z-statistic image for image "{self.effect}"')
+                return self.get_data_image(Statistic.effect)
+            return Statistic.z, nib.nifti1.load(self.z)
+        elif statistic == Statistic.standardizedEffect:
+            if self.variance is None:
+                logger.info(f'Cannot find variance image for image "{self.effect}"')
+                return self.get_data_image(Statistic.z)
+            if self.dof is None:
+                logger.info(
+                    f'Cannot find degrees of freedom image for image "{self.effect}"'
+                )
+                return self.get_data_image(Statistic.z)
+
+            effect_image = self.effect_image
+            variance_image = nib.nifti1.load(self.variance)
+            dof_image = nib.nifti1.load(self.dof)
+
+            effect = effect_image.get_fdata()
+            variance = variance_image.get_fdata()
+            dof = dof_image.get_fdata()
+            mask = self.mask_data
+
+            t = np.zeros_like(effect)
+            t[mask] = effect[mask] / np.sqrt(variance[mask])
+
+            standardized_coefficient = np.zeros_like(effect)
+            standardized_coefficient[mask] = t[mask] / np.sqrt(t[mask] ** 2 + dof[mask])
+
+            standardized_coefficient_fisherz = np.zeros_like(effect)
+            standardized_coefficient_fisherz[mask] = np.arctanh(
+                standardized_coefficient[mask]
+            )
+
+            standardized_coefficient_image = new_img_like(
+                effect_image, standardized_coefficient_fisherz, copy_header=True
+            )
+            return Statistic.standardizedEffect, standardized_coefficient_image
+        else:
+            raise NotImplementedError
+
+
+@dataclass
+class AtlasSignals:
+    array: npt.NDArray[np.float64]
+    coverages: npt.NDArray[np.float64]
+    statistic: str | None = None
+
+
 @dataclass
 class Atlas:
-    type: Literal["atlas", "modes"]
     name: str
     image: nib.analyze.AnalyzeImage
     labels: dict[int, str]
 
+    @abstractmethod
+    def apply(self, image_paths: ImagePaths) -> AtlasSignals:
+        raise NotImplementedError
+
+
+@dataclass
+class DiscreteAtlas(Atlas):
+    statistic: Statistic
+
+    def apply(self, image_paths: ImagePaths) -> AtlasSignals:
+        statistic, data_image = image_paths.get_data_image(self.statistic)
+        signals, coverage = mean_signals(
+            data_image,
+            self.image,
+            mask_image=image_paths.mask_image,
+            output_coverage=True,
+        )
+
+        if statistic == Statistic.standardizedEffect:
+            # Undo Fisher z-transformation
+            signals = np.tanh(signals)
+
+        return AtlasSignals(signals, np.array(coverage), statistic.name)
+
     @classmethod
     def from_args(
         cls,
-        type: Literal["atlas", "modes"],
         name: str,
-        image_path: Path | str,
-        labels_path: Path | str,
+        statistic: str,
+        image_path: str,
+        labels_path: str,
     ) -> Self:
-        image_path = Path(image_path)
+        labels, image = load_atlas(image_path, labels_path)
+        return cls(name, image, labels, Statistic[statistic])
 
-        labels_frame = read_spreadsheet(labels_path)
-        labels: dict[int, str] = dict()
-        for label_tuple in labels_frame.itertuples(index=False):
-            # First columnn is the index, second is the name.
-            labels[int(label_tuple[0])] = format_like_bids(str(label_tuple[1]))
 
-        image = nib.nifti1.load(image_path)
-        if not isinstance(image, nib.analyze.AnalyzeImage):
-            raise ValueError(f'"{image_path}" is not a nifti image')
-        return cls(type, name, image, labels)
+@dataclass
+class ProbabilisticAtlas(Atlas):
+    def apply(self, image_paths: ImagePaths) -> AtlasSignals:
+        var_cope_files = None
+        if image_paths.variance is not None:
+            var_cope_files = [image_paths.variance]
+        cope_img, var_cope_img = load_data(
+            [image_paths.effect], var_cope_files, [image_paths.mask], quiet=True
+        )
+        signals, coverage = mode_signals(
+            cope_img, var_cope_img, self.image, output_coverage=True
+        )
+        return AtlasSignals(signals, coverage)
+
+    @classmethod
+    def from_args(
+        cls,
+        name: str,
+        image_path: str,
+        labels_path: str,
+    ) -> Self:
+        labels, image = load_atlas(image_path, labels_path)
+        return cls(name, image, labels)
 
 
 def export(
     column_prefix: str | None,
     subjects: list[str],
-    cope_files: list[Path],
-    var_cope_files: Sequence[Path | None] | None,
-    mask_files: list[Path],
+    images: dict[str, list[Path]],
     regressors: dict[str, list[float]],
     contrasts: Sequence[TContrast | FContrast],
     atlases: list[Atlas],
@@ -68,29 +223,31 @@ def export(
     covariate_frame, _ = parse_design(regressors, contrasts)
     covariate_frame.index = pd.Index(subjects)
 
-    signals: dict[str, npt.NDArray] = OrderedDict()
-    coverages: dict[str, npt.NDArray] = OrderedDict()
+    signals: dict[str, npt.NDArray] = dict()
+    coverages: dict[str, npt.NDArray] = dict()
 
-    # Prepare for parallel processing.
-    num_inputs = len(cope_files)
-    if var_cope_files is None:
-        var_cope_files = [None] * num_inputs
+    # Prepare for parallel processing
+    cope_paths = images["effect"]
+    num_inputs = len(cope_paths)
     inner = partial(get_signals, atlases)
-    arg_tuples = zip(cope_files, var_cope_files, mask_files)
 
-    # Only start a pool if we are using more than one thread.
+    image_paths_list = [
+        ImagePaths(**dict(zip(images.keys(), paths))) for paths in zip(*images.values())
+    ]
+
+    # Only start a pool if we are using more than one thread
     if num_threads < 2:
         pool: Pool | None = None
-        it: Iterable = map(inner, arg_tuples)
+        it: Iterator[list[AtlasSignals]] = map(inner, image_paths_list)
         cm: ContextManager = nullcontext()
     else:
         pool = Pool(processes=num_threads)
-        it = pool.imap(inner, arg_tuples)
+        it = pool.imap(inner, image_paths_list)
         cm = pool
 
     with cm:
-        # Top list level is subjects, second level is atlases.
-        signal_rows: list[list[tuple[npt.NDArray, npt.NDArray]]] = list(
+        # Top list level is subjects, second level is atlases
+        signal_rows: list[list[AtlasSignals]] = list(
             tqdm(it, unit="images", desc="extracting signals", total=num_inputs)
         )
 
@@ -98,20 +255,33 @@ def export(
         pool.terminate()
         pool.join()
 
-    # Transpose subjects and atlases.
+    # Transpose subjects and atlases
     signal_columns = (list(c) for c in zip(*signal_rows))
+
     for atlas, signal_column in zip(atlases, signal_columns):
-        # Unpack signal/coverage.
-        signal_list, coverage_list = (list(c) for c in zip(*signal_column))
-        signal_array: npt.NDArray = np.vstack(signal_list)
-        coverage_array: npt.NDArray = np.vstack(coverage_list)
+        # Unpack signal/coverage
+        statistics: set[str | None] = set(signal.statistic for signal in signal_column)
+        if len(statistics) > 1:
+            raise ValueError(
+                "Inconsistent statistics were used across subjects. "
+                "Please check that processing completed for all subjects "
+                "and that all required outputs are available"
+            )
+        (statistic,) = statistics
+        signal_array: npt.NDArray = np.vstack(
+            [signal.array for signal in signal_column]
+        )
+        coverage_array: npt.NDArray = np.vstack(
+            [signal.coverages for signal in signal_column]
+        )
 
         for i in range(signal_array.shape[1]):
             label = atlas.labels[i + 1]
-            signals[f"{column_prefix}_{atlas.name}_label-{label}"] = signal_array[:, i]
-            coverages[f"{column_prefix}_{atlas.name}_label-{label}"] = coverage_array[
-                :, i
-            ]
+            column = f"{column_prefix}_{atlas.name}_label-{label}"
+            if statistic is not None:
+                column = f"{column}_stat-{statistic}"
+            signals[column] = signal_array[:, i]
+            coverages[column] = coverage_array[:, i]
 
     signals_frame = pd.DataFrame.from_dict(signals)
     signals_frame.index = pd.Index(subjects)
@@ -127,34 +297,6 @@ def export(
 
 def get_signals(
     atlases: list[Atlas],
-    path_tuple: tuple[Path, Path | None, Path],
-) -> list[tuple[npt.NDArray, npt.NDArray]]:
-    (cope_file, var_cope_file, mask_file) = path_tuple
-
-    var_cope_files = None
-    if var_cope_file is not None:
-        var_cope_files = [var_cope_file]
-    cope_img, var_cope_img = load_data(
-        [cope_file], var_cope_files, [mask_file], quiet=True
-    )
-
-    results: list[tuple[npt.NDArray, npt.NDArray]] = list()
-    for atlas in atlases:
-        if atlas.type == "atlas":
-            cope_data = np.asanyarray(cope_img.dataobj)
-            mask_img = new_img_like(cope_img, np.isfinite(cope_data))
-            s, c = mean_signals(
-                cope_img,
-                atlas.image,
-                mask_image=mask_img,
-                output_coverage=True,
-            )
-            results.append((s, np.array(c)))
-        elif atlas.type == "modes":
-            results.append(
-                mode_signals(cope_img, var_cope_img, atlas.image, output_coverage=True)
-            )
-        else:
-            raise ValueError(f'Unknown atlas type "{atlas.type}".')
-
-    return results
+    image_paths: ImagePaths,
+) -> list[AtlasSignals]:
+    return [atlas.apply(image_paths) for atlas in atlases]


### PR DESCRIPTION
Allow for more customization
The previous default was `effect`, which just averaged the parameter estimates across atlas region voxels.
This commit adds `z`, which averages the z-statistic. It also adds `standardizedEffect`, which is scaled from -1 to 1, and `cohensD` to provide effect size measures.