### PR TITLE
fix build recipe for rmath on macos

### DIFF
--- a/recipes/rmath/build.sh
+++ b/recipes/rmath/build.sh
@@ -25,10 +25,10 @@ echo "Configuring..." # Configure with verbose output
     --with-readline=no \
     --with-recommended-packages=no \
     --with-tcltk=no \
-    --with-x=no || { echo "Configuration failed"; exit 1; }
+    --with-x=no
 
 echo "Entering src/nmath/standalone directory..."
-pushd src/nmath/standalone || { echo "Failed to enter src/nmath/standalone directory"; exit 1; }
+pushd src/nmath/standalone
 
 # Determine number of cores for make command differently based on OS
 if [[ $(uname) == "Darwin" ]]; then
@@ -38,11 +38,11 @@ else
 fi
 
 echo "Building with ${NUM_CORES} cores..."
-make --jobs="${NUM_CORES}" shared || { echo "Make failed"; exit 1; }
+make --jobs="${NUM_CORES}" shared
 echo "Installing..."
-make install || { echo "Make install failed"; exit 1; }
+make install
 
 echo "Exiting src/nmath/standalone directory..."
-popd || exit
+popd
 
 echo "Build script completed successfully."

--- a/recipes/rmath/build.sh
+++ b/recipes/rmath/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+set -e # Stop on any error
 export LIBnn=lib
 
+echo "Configuring..." # Configure with verbose output
 ./configure \
     --prefix="${PREFIX}" \
     --enable-lto=yes \
@@ -22,13 +24,26 @@ export LIBnn=lib
     --with-readline=no \
     --with-recommended-packages=no \
     --with-tcltk=no \
-    --with-x=no
+    --with-x=no || { echo "Configuration failed"; exit 1; }
 
-pushd src/nmath/standalone || exit
+echo "Entering src/nmath/standalone directory..."
+pushd src/nmath/standalone || { echo "Failed to enter src/nmath/standalone directory"; exit 1; }
 
-make --jobs="$(nproc)" shared
-make install
+# Determine number of cores for make command differently based on OS
+if [[ $(uname) == "Darwin" ]]; then
+    NUM_CORES=$(sysctl -n hw.ncpu)
+else
+    NUM_CORES=$(nproc)
+fi
 
-find "${PREFIX}"
+echo "Building with ${NUM_CORES} cores..."
+make --jobs="${NUM_CORES}" shared || { echo "Make failed"; exit 1; }
+echo "Installing..."
+make install || { echo "Make install failed"; exit 1; }
 
+find "${PREFIX}" || { echo "Find command failed"; exit 1; }
+
+echo "Exiting src/nmath/standalone directory..."
 popd || exit
+
+echo "Build script completed successfully."

--- a/recipes/rmath/build.sh
+++ b/recipes/rmath/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e # Stop on any error
+
 export LIBnn=lib
 
 echo "Configuring..." # Configure with verbose output
@@ -40,8 +41,6 @@ echo "Building with ${NUM_CORES} cores..."
 make --jobs="${NUM_CORES}" shared || { echo "Make failed"; exit 1; }
 echo "Installing..."
 make install || { echo "Make install failed"; exit 1; }
-
-find "${PREFIX}" || { echo "Find command failed"; exit 1; }
 
 echo "Exiting src/nmath/standalone directory..."
 popd || exit

--- a/recipes/rmath/meta.yaml
+++ b/recipes/rmath/meta.yaml
@@ -1,3 +1,5 @@
+{% set platform = target_platform or 'unknown' %}
+
 package:
   name: rmath
   version: 4.3.1
@@ -21,7 +23,11 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libRmath.so
+    {% if platform.startswith("osx") %}
+    - test -f ${PREFIX}/lib/libRmath.dylib  # testing on macOS
+    {% else %}
+    - test -f ${PREFIX}/lib/libRmath.so     # testing on Linux and others
+    {% endif %}
     - test -f ${PREFIX}/include/Rmath.h
 
 about:

--- a/src/halfpipe/stats/miscmaths.py
+++ b/src/halfpipe/stats/miscmaths.py
@@ -5,7 +5,6 @@
 import sys
 
 import numpy as np
-import sys
 from llvmlite import binding
 from numba import njit, vectorize
 from numba.core import types, typing
@@ -105,7 +104,6 @@ def pchisq(
     lower_tail: bool = True,
     log_p: bool = False,
 ) -> float:
-    
     return c_pchisq(x, degrees_of_freedom, np.int32(lower_tail), np.int32(log_p))
 
 

--- a/src/halfpipe/stats/miscmaths.py
+++ b/src/halfpipe/stats/miscmaths.py
@@ -2,6 +2,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
+import sys
+
 import numpy as np
 import sys
 from llvmlite import binding
@@ -10,7 +12,7 @@ from numba.core import types, typing
 
 if sys.platform == "darwin":
     binding.load_library_permanently("libRmath.dylib")
-else: 
+else:
     binding.load_library_permanently("libRmath.so")
 
 c_pt = types.ExternalFunction(

--- a/src/halfpipe/stats/miscmaths.py
+++ b/src/halfpipe/stats/miscmaths.py
@@ -10,10 +10,9 @@ from numba import njit, vectorize
 from numba.core import types, typing
 
 if sys.platform == "darwin":
-    binding.load_library_permanently("libRmath.dylib")
+    binding.load_library_permanently("libRmath.dylib")  # pragma: no cover
 else:
-    binding.load_library_permanently("libRmath.so")
-
+    binding.load_library_permanently("libRmath.so")  # pragma: no cover
 c_pt = types.ExternalFunction(
     "pt",
     typing.Signature(

--- a/src/halfpipe/stats/miscmaths.py
+++ b/src/halfpipe/stats/miscmaths.py
@@ -3,11 +3,16 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 import numpy as np
+import sys
 from llvmlite import binding
 from numba import njit, vectorize
 from numba.core import types, typing
 
-binding.load_library_permanently("libRmath.so")
+if sys.platform == "darwin":
+    binding.load_library_permanently("libRmath.dylib")
+else: 
+    binding.load_library_permanently("libRmath.so")
+
 c_pt = types.ExternalFunction(
     "pt",
     typing.Signature(
@@ -98,6 +103,7 @@ def pchisq(
     lower_tail: bool = True,
     log_p: bool = False,
 ) -> float:
+    
     return c_pchisq(x, degrees_of_freedom, np.int32(lower_tail), np.int32(log_p))
 
 


### PR DESCRIPTION
This branch fixes the rmath build by updating tests and binding to the right extension for developers using mac. Adds more verbosity in the build script for  logging and debugging purposes. 