### PR TITLE
Fix metadata ingest error for qform rounding errors

### DIFF
--- a/src/halfpipe/ingest/metadata/direction.py
+++ b/src/halfpipe/ingest/metadata/direction.py
@@ -18,7 +18,7 @@ def get_axcodes_set(path_pattern: str):
         header, _ = NiftiheaderLoader.load(file_path)
         if not isinstance(header, nib.nifti1.Nifti1Header):
             continue
-        axcodes_set.add(nib.orientations.aff2axcodes(header.get_qform()))
+        axcodes_set.add(nib.orientations.aff2axcodes(header.get_best_affine()))
 
     return axcodes_set
 

--- a/tests/ingest/metadata/test_direction.py
+++ b/tests/ingest/metadata/test_direction.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+from halfpipe.ingest.metadata.direction import get_axcodes_set
+from halfpipe.resource import get as get_resource
+
+from ...resource import setup as setup_test_resources
+
+
+def test_get_axcodes_set():
+    """
+    Regression test for the `get_axcodes_set` function.
+    Makes sure that bad qform information in image headers
+     does not break the program. Original error was
+    `ValueError: w2 should be positive, but is -9.483971e-07`
+    """
+    setup_test_resources()
+    path = get_resource("bad_quaternion.nii.gz")
+    get_axcodes_set(path)

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -19,6 +19,7 @@ test_online_resources = {
     "tpl-MNI152NLin2009cAsym_res-02_atlas-DiFuMo_desc-1024dimensions_probseg.nii.gz": "https://download.fmri.science/test_resources/tpl-MNI152NLin2009cAsym_res-02_atlas-DiFuMo_desc-1024dimensions_probseg.nii.gz",
     "sub-0003_fmriprep_derivatives.zip": "https://download.fmri.science/test_resources/sub-0003_fmriprep_derivatives.zip",
     "atlases.zip": "https://github.com/HALFpipe/Atlases/releases/download/1.0.1/atlases.zip",
+    "bad_quaternion.nii.gz": "https://github.com/spinalcordtoolbox/spinalcordtoolbox/files/8492834/bad_quaternion.nii.gz",
 }
 
 


### PR DESCRIPTION
Replace `get_qform` with `get_best_affine` to avoid the problem. This issue is documented at
https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3703 and https://github.com/nipy/nibabel/issues/626

Reported-by: Nadza Dzinalija 