### PR TITLE
Fix group level command derivatives collection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: check-symlinks
       - id: mixed-line-ending
       - id: check-case-conflict
-      - id: fix-encoding-pragma
       - id: fix-byte-order-marker
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -33,4 +32,10 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          [numpy, types-chardet, types-requests, types-tabulate, typing_extensions]
+          [
+            numpy,
+            types-chardet,
+            types-requests,
+            types-tabulate,
+            typing_extensions,
+          ]

--- a/src/halfpipe/ingest/metadata/database.py
+++ b/src/halfpipe/ingest/metadata/database.py
@@ -55,7 +55,7 @@ class DatabaseMetadataLoader(Loader):
                                 value = abs(e1 - e2)
 
         if key == "echo_time":  # calculate from associated file
-            if fileobj.datatype == "fmap" and fileobj.suffix.startswith("phase"):
+            if fileobj.datatype == "fmap" and fileobj.suffix is not None and fileobj.suffix.startswith("phase"):
                 filepath = fileobj.path
                 suffix = dict(phase1="magnitude1", phase2="magnitude2").get(fileobj.suffix)
                 if suffix is not None:
@@ -71,7 +71,10 @@ class DatabaseMetadataLoader(Loader):
                 try:
                     spreadsheet = read_spreadsheet(slice_timing_file)
                     valuearray = np.ravel(spreadsheet.values).astype(np.float64)
-                    value = list(valuearray.tolist())
+                    valuelist = valuearray.tolist()
+                    if not isinstance(valuelist, list):
+                        raise TypeError
+                    value = valuelist
                 except Exception as e:
                     logger.warning(
                         f'Ignored exception when loading slice_timing_file "{slice_timing_file}":',

--- a/src/halfpipe/ingest/metadata/niftiheader.py
+++ b/src/halfpipe/ingest/metadata/niftiheader.py
@@ -3,10 +3,9 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 import re
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import nibabel as nib
-import numpy as np
 import pint
 
 from ...logging import logger
@@ -20,9 +19,8 @@ descrip_pattern = re.compile(r"(?P<var_name>\w+)=(?P<value>(\d+(\.\d*)?|\.\d+)([
 def parse_descrip(header: nib.nifti1.Nifti1Header) -> dict[str, float]:
     descrip_dict = dict()
 
-    descrip_array = header.get("descrip")
-    assert isinstance(descrip_array, np.ndarray)
-    descrip = descrip_array.tolist().decode()
+    descrip_array: Any = header.get("descrip")
+    descrip = descrip_array.tolist().decode()  # type: ignore
 
     for m in descrip_pattern.finditer(descrip):
         var_name = m.group("var_name")

--- a/src/halfpipe/result/bids/images.py
+++ b/src/halfpipe/result/bids/images.py
@@ -68,13 +68,13 @@ def _to_bids_derivatives(key: str, inpath: Path, tags: dict[str, str]) -> Path:
         return make_bids_path(inpath, "image", tags, suffix=key)
 
 
-def _load_result(file_index: FileIndex, tags: Mapping[str, str]) -> ResultDict | None:
+def _load_result(file_index: FileIndex, tags: Mapping[str, str | None]) -> ResultDict | None:
     paths = file_index.get(**tags)
     if paths is None or len(paths) == 0:
         return None
 
     result: ResultDict = defaultdict(dict)
-    result["tags"] = dict(tags)
+    result["tags"] = {key: value for key, value in tags.items() if value is not None}
 
     for path in paths:
         if path.suffix == ".json":
@@ -112,6 +112,7 @@ def load_images(file_index: FileIndex, num_threads: int = 1) -> list[ResultDict]
     image_group_entities = set(entities) - {"stat", "algorithm"}
 
     groups = file_index.get_tag_groups(image_group_entities)
+
     cm, iterator = make_pool_or_null_context(
         groups,
         callable=partial(_load_result, file_index),

--- a/src/halfpipe/stats/base.py
+++ b/src/halfpipe/stats/base.py
@@ -27,10 +27,10 @@ class ModelAlgorithm(ABC):
     ) -> dict | None:
         raise NotImplementedError()
 
-    @staticmethod
+    @classmethod
     @abstractmethod
     def write_outputs(
-        ref_img: nib.analyze.AnalyzeImage, cmatdict: dict, voxel_results: dict
+        cls, reference_image: nib.analyze.AnalyzeImage, contrast_matrices: dict, voxel_results: dict
     ) -> dict[str, list[Literal[False] | str]]:
         raise NotImplementedError()
 
@@ -57,6 +57,8 @@ class ModelAlgorithm(ABC):
         array[*zip(*coordinates, strict=False)] = np.stack(values).squeeze()
 
         image = new_img_like(reference_image, array, copy_header=True)
+        if not isinstance(image.header, nib.nifti1.Nifti1Header):
+            raise TypeError("Only nifti1 headers are supported")
         image.header.set_data_dtype(np.float64)
 
         image_path = Path.cwd() / f"{out_name}.nii.gz"

--- a/src/halfpipe/stats/flame1.py
+++ b/src/halfpipe/stats/flame1.py
@@ -117,13 +117,13 @@ def t_ols_contrast(
     degrees_of_freedom: int,
     t_contrast: npt.NDArray[np.float64],
 ) -> TContrastResult:
-    cope = (t_contrast @ regression_weights).ravel().item()
+    cope: float = (t_contrast @ regression_weights).ravel().item()
 
     a = np.linalg.lstsq(gram_matrix, t_contrast.T, rcond=None)[0]
-    var_cope = (t_contrast @ a).ravel().item()
+    var_cope: Any = (t_contrast @ a).ravel().item()
 
-    t = cope / np.sqrt(var_cope)
-    z = t2z_convert(t, degrees_of_freedom)
+    t: float = cope / np.sqrt(var_cope)
+    z: float = t2z_convert(t, degrees_of_freedom)
 
     return TContrastResult(cope, var_cope, t, z)
 

--- a/src/halfpipe/stats/heterogeneity.py
+++ b/src/halfpipe/stats/heterogeneity.py
@@ -120,10 +120,10 @@ def reml_hessian(
 
 def ml_neg_log_lik(
     ϑ: float,
-    y: npt.NDArray[np.floating],
-    x: npt.NDArray[np.floating] | None,
-    s: npt.NDArray[np.floating],
-    γ: npt.NDArray[np.floating],
+    y: npt.NDArray[np.float64],
+    x: npt.NDArray[np.float64] | None,
+    s: npt.NDArray[np.float64],
+    γ: npt.NDArray[np.float64],
 ):
     if ϑ < 0:
         return np.inf
@@ -287,7 +287,7 @@ class Heterogeneity(ModelAlgorithm):
         return voxel_result
 
     @classmethod
-    def write_outputs(cls, ref_img: nib.analyze.AnalyzeImage, cmatdict: dict, voxel_results: dict) -> dict:
+    def write_outputs(cls, reference_image: nib.analyze.AnalyzeImage, contrast_matrices: dict, voxel_results: dict) -> dict:
         output_files = dict()
 
         rdf = pd.DataFrame.from_records(voxel_results)
@@ -295,7 +295,7 @@ class Heterogeneity(ModelAlgorithm):
         for map_name, series in rdf.iterrows():
             assert isinstance(map_name, str)
 
-            fname = cls.write_map(ref_img, map_name, series)
+            fname = cls.write_map(reference_image, map_name, series)
             output_files[map_name] = str(fname)
 
         return output_files

--- a/tests/collect/test_derivatives.py
+++ b/tests/collect/test_derivatives.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import json
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+from halfpipe.collect.derivatives import collect_halfpipe_derivatives
+
+paths = [
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/task-fearful/sub-STRADL_task-fearful_feature-fearful2_taskcontrast-faceNegVsControl_mask.nii.gz",
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/sub-STRADL_task-fearful_stat-tsnr_boldmap.nii.gz",
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/task-fearful/sub-STRADL_task-fearful_feature-fearful1_taskcontrast-faceNegVsNeut_stat-sigmasquareds_statmap.nii.gz",
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/task-fearful/sub-STRADL_task-fearful_feature-fearful1_taskcontrast-faceNegVsControl_stat-variance_statmap.nii.gz",
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/task-fearful/sub-STRADL_task-fearful_feature-fearful3_taskcontrast-faceVsControl_stat-z_statmap.nii.gz",
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/task-fearful/sub-STRADL_task-fearful_feature-fearful1_taskcontrast-faceNegVsControl_stat-dof_statmap.nii.gz",
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/task-fearful/sub-STRADL_task-fearful_feature-fearful3_taskcontrast-faceVsControl_stat-effect_statmap.nii.gz",
+    "working_directory/derivatives/halfpipe/sub-STRADL/func/task-fearful/sub-STRADL_task-fearful_feature-fearful1_desc-contrast_matrix.tsv",
+]
+
+
+def test_collect_halfpipe_derivates(tmp_path: Path) -> None:
+    for path_str in paths:
+        path = tmp_path / path_str
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.name.endswith(".nii.gz"):
+            image = nib.nifti1.Nifti1Image(np.random.rand(10, 10, 10), np.eye(4))
+            nib.loadsave.save(image, path)
+        else:
+            with path.open("wt") as file_handle:
+                file_handle.write("1\t2\t3\n")
+        if "statmap" in path.name:
+            with (path.parent / f"{path.name.removesuffix('.nii.gz')}.json").open("wt") as file_handle:
+                json.dump(dict(task_name="fearful", dummy_scans=6), file_handle)
+    with (tmp_path / "working_directory/spec.json").open("wt") as file_handle:
+        json.dump(dict(), file_handle)
+    results = collect_halfpipe_derivatives([tmp_path / "working_directory"])
+    for result in results:
+        # Ensure that we don't accidentally combine too many images into one result
+        assert len(result["images"]) < 3


### PR DESCRIPTION
`collect_halfpipe_derviatives` uses `FileIndex.get_tag_groups` to find which images to group into `Result` dictionaries. Previously, the groups would omit any tags not defined for an image. This led to very general queries for images with very few tags (such as tSNR), and the `Result` would encompass many more images than expected. We now explicily return None for tags not defined, so queries stay restrictive.

Reported-by: Rosie Tatham <Rosie.Tatham@ed.ac.uk>