### PR TITLE
fetch TotalReadoutTime

### DIFF
--- a/src/halfpipe/model/metadata.py
+++ b/src/halfpipe/model/metadata.py
@@ -65,6 +65,7 @@ class PEDirMetadataSchema(BaseMetadataSchema):
         validate=validate.Range(min=0.0),
     )
 
+
 class TEMetadataSchema(BaseMetadataSchema):
     echo_time = fields.Float(
         metadata=dict(
@@ -166,12 +167,13 @@ class SpreadsheetMetadataSchema(Schema):
         if len(names) > len(set(names)):
             raise ValidationError("Duplicate variable name")
 
+
 metadata_schemas: list[Type[Schema]] = [
     PhaseDiffMetadataSchema,
     EventsMetadataSchema,
     RefMetadataSchema,
     BoldMetadataSchema,
-    BIDSFmapMetadataSchema
+    BIDSFmapMetadataSchema,
 ]
 
 MetadataSchema = Schema.from_dict({k: v for schema in metadata_schemas for k, v in schema().fields.items()})


### PR DESCRIPTION
`TotalReadoutTime` was not fetched for PePolar fieldmaps. This resulted in errors with BIDS validation and crashed fmriprep. 