### PR TITLE
Fix TypeError in build

### DIFF
--- a/src/build/conda.py
+++ b/src/build/conda.py
@@ -13,7 +13,7 @@ from conda_build.build import clean_build
 from conda_build.config import Config
 from conda_build.metadata import MetaDataTuple
 from loguru import logger
-from rattler.index import S3Credentials, index_fs, index_s3
+from rattler.index import index_fs, index_s3
 from setuptools_scm import get_version
 from tqdm.auto import tqdm
 
@@ -156,8 +156,8 @@ async def main() -> None:
         await index_fs(channel_directory=build_path, write_zst=False, write_shards=False)
 
     if push and endpoint_url is not None:
-        credentials = S3Credentials(region="auto", endpoint_url=endpoint_url)
-        await index_s3(channel_url=f"s3://{s3_bucket}", credentials=credentials)
+        credentials = dict(region="auto", endpoint_url=endpoint_url)
+        await index_s3(channel_url=f"s3://{s3_bucket}", credentials=credentials)  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The new py-rattler syntax fails with
`TypeError: unexpected type: 'S3Credentials' object cannot be converted to 'Mapping'` 
Try passing a mapping instead