### PR TITLE
Add --bids-database-dir and --spec-file command line options

### DIFF
--- a/src/halfpipe/cli/parser.py
+++ b/src/halfpipe/cli/parser.py
@@ -42,6 +42,8 @@ def build_parser() -> ArgumentParser:
         steponlygroup.add_argument(f"--skip-{step}", action="store_true", default=False)
 
     workflowgroup = parser.add_argument_group("workflow", "")
+    workflowgroup.add_argument("--bids-database-dir", type=Path)
+    workflowgroup.add_argument("--spec-path", type=Path)
     workflowgroup.add_argument("--nipype-omp-nthreads", type=int)
     workflowgroup.add_argument("--fs-license-file")
     workflowgroup.add_argument(

--- a/src/halfpipe/cli/run.py
+++ b/src/halfpipe/cli/run.py
@@ -66,7 +66,7 @@ def run_stage_workflow(opts):
     from ..workflows.base import init_workflow
     from ..workflows.execgraph import init_execgraph
 
-    workflow = init_workflow(opts.workdir)
+    workflow = init_workflow(opts.workdir, spec_path=opts.spec_file, bids_database_dir=opts.bids_database_dir)
 
     if workflow is None:
         return None

--- a/src/halfpipe/ingest/database.py
+++ b/src/halfpipe/ingest/database.py
@@ -3,6 +3,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 from hashlib import sha1
+from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from ..logging import logger
@@ -13,12 +14,12 @@ from .resolve import ResolvedSpec
 
 
 class Database:
-    def __init__(self, spec: Spec | ResolvedSpec) -> None:
+    def __init__(self, spec: Spec | ResolvedSpec, bids_database_dir: Path | None = None) -> None:
         resolved_spec = None
         if isinstance(spec, ResolvedSpec):
             resolved_spec = spec
         elif isinstance(spec, Spec):
-            resolved_spec = ResolvedSpec(spec)
+            resolved_spec = ResolvedSpec(spec, bids_database_dir=bids_database_dir)
         else:
             raise ValueError("Need to initialize Database with a Spec or ResolvedSpec")
         self.resolved_spec = resolved_spec

--- a/src/halfpipe/ingest/resolve.py
+++ b/src/halfpipe/ingest/resolve.py
@@ -5,6 +5,7 @@
 from collections import defaultdict
 from itertools import product
 from os.path import basename
+from pathlib import Path
 from pprint import pformat
 from typing import Any, Generator
 
@@ -93,8 +94,9 @@ def to_fileobj(obj: BIDSFile, basemetadata: dict) -> File | None:
 
 
 class ResolvedSpec:
-    def __init__(self, spec: Spec) -> None:
+    def __init__(self, spec: Spec, bids_database_dir: Path | None = None) -> None:
         self.spec = spec
+        self.bids_database_dir = bids_database_dir
 
         self.fileobj_by_filepaths: dict[str, File] = dict()
 
@@ -161,6 +163,7 @@ class ResolvedSpec:
         layout = BIDSLayout(
             root=fileobj.path,
             reset_database=True,  # force reindex in case files have changed
+            database_path=self.bids_database_dir,
             validate=validate,
             indexer=BIDSLayoutIndexer(
                 validate=validate,

--- a/src/halfpipe/workflows/base.py
+++ b/src/halfpipe/workflows/base.py
@@ -25,7 +25,9 @@ from .post_processing import PostProcessingFactory
 from .stats import StatsFactory
 
 
-def init_workflow(workdir: Path, spec: Optional[Spec] = None) -> IdentifiableWorkflow:
+def init_workflow(
+    workdir: Path, spec: Optional[Spec] = None, spec_path: Path | None = None, bids_database_dir: Path | None = None
+) -> IdentifiableWorkflow:
     """
     initialize nipype workflow
     :param workdir
@@ -34,11 +36,11 @@ def init_workflow(workdir: Path, spec: Optional[Spec] = None) -> IdentifiableWor
     from ..collect.bold import collect_bold_files
 
     if not spec:
-        spec = load_spec(workdir=workdir)
+        spec = load_spec(workdir=workdir, path=spec_path)
 
     assert spec is not None, "A spec file could not be loaded"
     logger.info("Initializing file database")
-    database = Database(spec)
+    database = Database(spec, bids_database_dir=bids_database_dir)
     # uuid depends on the spec file, the files found and the version of the program
     uuid = uuid5(spec.uuid, database.sha1 + __version__)
 


### PR DESCRIPTION
For compatibility with Nipoppy, we need a mechanism to restrict inputs to one subject. The PyBIDS mechanism for this is passing a --bids-database-dir containing a database for only one subject. The --spec-file lets the user pass a specific spec file to be used for workflow construction.