### PR TITLE
spreadsheet is a string

### DIFF
--- a/src/halfpipe/design.py
+++ b/src/halfpipe/design.py
@@ -49,6 +49,10 @@ def prepare_data_frame(
     subjects: list[str] | None = None,
     na_action: Literal["impute"] | None = None,
 ) -> pd.DataFrame:
+    logger.info(f"Checking content of the spreadsheet variable: {spreadsheet}")
+    # normalize `spreadsheet` into a Path if it is a string
+    if isinstance(spreadsheet, str):
+        spreadsheet = Path(spreadsheet)
     if isinstance(spreadsheet, Path):
         data_frame: pd.DataFrame = read_spreadsheet(spreadsheet, dtype=str)
     else:


### PR DESCRIPTION
recently posted error shows this:
```
 File "/opt/conda/envs/fmriprep/lib/python3.11/site-packages/halfpipe/design.py", line 55, in prepare_data_frame
│ 	    data_frame = spreadsheet.copy()
│ 	                 ^^^^^^^^^^^^^^^^
└─	AttributeError: 'str' object has no attribute 'copy'
```
I think that what happens is that instead of path a string is passed
