### PR TITLE
adding extended epi test

### DIFF
--- a/tests/workflows/test_workflow.py
+++ b/tests/workflows/test_workflow.py
@@ -175,27 +175,22 @@ def test_feature_extraction(tmp_path: Path, mock_spec: Spec) -> None:
 
 
 @pytest.mark.parametrize(
-    ("fieldmap_type", "bids_data"),
+    ("fieldmap_type", "extend_tasks"),
     [
-        pytest.param(
-            "phasediff",
-            {"extend_tasks": False},
-            id="phasediff-original",
-        ),
-        pytest.param(
-            "epi",
-            {"extend_tasks": False},
-            id="epi-original",
-        ),
-        pytest.param(
-            "epi",
-            {"extend_tasks": True},
-            id="epi-extended",
-        ),
+        pytest.param("phasediff", False, id="phasediff-original"),
+        pytest.param("epi", False, id="epi-original"),
+        pytest.param("epi", True, id="epi-extended"),
     ],
-    indirect=["bids_data"],
 )
-def test_with_fieldmaps(tmp_path: Path, bids_data: Path, mock_spec: Spec, fieldmap_type: str) -> None:
+def test_with_fieldmaps(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    extend_tasks: bool,
+    fieldmap_type: str,
+    mock_spec: Spec,
+) -> None:
+    bids_data = request.getfixturevalue("bids_data_with_runs" if extend_tasks else "bids_data")
+
     bids_path = tmp_path / "bids"
     shutil.copytree(bids_data, bids_path)
 


### PR DESCRIPTION
This extension creates a bids data where each task have a 'run' suffix. The purpose of this is that there was a bug that caused bad fmap resolution in such cases (no fmap directory was created in rawdata).